### PR TITLE
Lowering tags for sorting.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Lowering tags for sorting.
+  [mathias.leimgruber]
 
 
 1.1.0 (2013-08-29)

--- a/ftw/tagging/portlets/tags.py
+++ b/ftw/tagging/portlets/tags.py
@@ -82,7 +82,8 @@ class Renderer(base.Renderer):
                             font_size=round(size, 1))
                 tag_cloud.append(info)
 
-            tag_cloud.sort(lambda x, y: cmp(x['title'], y['title']))
+            tag_cloud.sort(lambda x, y: cmp(x['title'].lower(),
+                                            y['title'].lower()))
             self.tag_cloud = tag_cloud
         else:
             self.tag_cloud = []


### PR DESCRIPTION
Tags with small letters appeared at the bottom. Fix -> `lower` tags while comparing. 
