### PR TITLE
Fix tests.

### DIFF
--- a/ftw/tagging/tests/__init__.py
+++ b/ftw/tagging/tests/__init__.py
@@ -1,7 +1,7 @@
 from ftw.tagging.testing import FUNCTIONAL_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 import transaction
 
 

--- a/ftw/tagging/tests/test_uninstall.py
+++ b/ftw/tagging/tests/test_uninstall.py
@@ -1,8 +1,8 @@
 from ftw.testing import IS_PLONE_5
 from ftw.testing.genericsetup import GenericSetupUninstallMixin
 from ftw.testing.genericsetup import apply_generic_setup_layer
-from unittest2 import TestCase
-from unittest2 import skipUnless
+from unittest import TestCase
+from unittest import skipUnless
 
 
 @apply_generic_setup_layer

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ tests_require = [
     'collective.testcaselayer',
     'ftw.builder',
     'ftw.testbrowser',
-    'ftw.testing',
+    'ftw.testing<2a',
     'plone.app.contenttypes',
     ]
 


### PR DESCRIPTION
- Downgrade ftw.testing so that mock tests still work.
- Use unittest instead of unittest2 (dependency was not declared).